### PR TITLE
Cme softdeletable tu

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Headoo\ElasticSearchBundle\Command;
+
+use Doctrine\ORM\EntityManager;
+use Headoo\ElasticSearchBundle\Helper\ElasticSearchHelper;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractCommand  extends ContainerAwareCommand
+{
+    const LINE_LENGTH = 70;
+    const CLEAR_LINE = "\r\e[2K\r";
+
+    const EXIT_SUCCESS = 0;
+    const EXIT_FAILED = 127;
+
+    /** @var OutputInterface */
+    protected $output;
+    /** @var integer */
+    protected $threads;
+    /** @var integer */
+    protected $limit;
+    /** @var integer */
+    protected $offset;
+    /** @var bool  */
+    protected $batch = false;
+    /** @var string */
+    protected $type;
+    /** @var array */
+    protected $aTypes;
+    /** @var ElasticSearchHelper */
+    protected $elasticSearchHelper;
+    /** @var array */
+    protected $mappings;
+    /** @var EntityManager */
+    protected $entityManager;
+    /** @var bool */
+    protected $reset = false;
+    /** @var bool $verbose More verbose */
+    protected $verbose = false;
+    /** @var bool $dryRun Do not make any change on ES */
+    protected $dryRun = false;
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function init(InputInterface $input, OutputInterface $output)
+    {
+        $this->readOption($input);
+
+        $this->output              = $output;
+        $this->elasticSearchHelper = $this->getContainer()->get('headoo.elasticsearch.helper');
+        $this->mappings            = $this->getContainer()->getParameter('elastica_mappings');
+        $this->entityManager       = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $this->aTypes = array_keys($this->mappings);
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function readOption(InputInterface $input)
+    {
+        $this->limit  = $input->getOption('limit') ?: null;
+        $this->offset = $input->getOption('offset') ?: 0;
+        $this->type   = $input->getOption('type');
+        $this->batch  = $input->getOption('batch');
+
+        if ($input->hasOption('reset')) {
+            $this->reset   = $input->getOption('reset');
+        }
+
+        if ($input->hasOption('threads')) {
+            $this->threads = $input->getOption('threads') ?: 2;
+        }
+
+        if ($input->hasOption('dry-run')) {
+            $this->dryRun  = $input->getOption('dry-run');
+        }
+
+        if ($input->hasOption('verbose')) {
+            $this->verbose = $input->getOption('verbose');
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param int $max
+     * @return ProgressBar
+     */
+    protected function getProgressBar($output, $max)
+    {
+        $progressBar = new ProgressBar($output, $max);
+
+        if ($this->verbose) {
+            $progressBar->setFormat('%message% Doc. %percent%% [%bar%] (%elapsed% - %estimated%) (%memory%)' . "\r");
+        } else {
+            $progressBar->setFormat('%message% %percent%% [%bar%] (%elapsed% - %estimated%)' . "\r");
+        }
+
+        $progressBar->setMessage('');
+        $progressBar->start();
+
+        return $progressBar;
+    }
+
+    /**
+     * @param $msg
+     * @return string
+     */
+    protected function completeLine($msg)
+    {
+        $nbrAstrix = (self::LINE_LENGTH - strlen($msg) - 2) / 2;
+
+        if ($nbrAstrix <= 0) {
+            return $msg;
+        }
+
+        $sAstrix = str_repeat('*', $nbrAstrix);
+        $sReturn = "$sAstrix $msg $sAstrix";
+
+        return (strlen($sReturn) == self::LINE_LENGTH)
+            ? $sReturn
+            : $sReturn . '*';
+    }
+
+    /**
+     * @param string $sType
+     * @return \Elastica\Index
+     */
+    protected function getIndexFromType($sType)
+    {
+        $connection = $this->mappings[$sType]['connection'];
+
+        $index_name = $this->getContainer()
+            ->get('headoo.elasticsearch.handler')
+            ->getIndexName($sType);
+
+        return $this->elasticSearchHelper
+            ->getClient($connection)
+            ->getIndex($index_name);
+    }
+
+    /**
+     * @param string $sType
+     * @return \Doctrine\ORM\EntityRepository
+     */
+    protected function getRepositoryFromType($sType)
+    {
+        return $this->entityManager->getRepository($this->mappings[$sType]['class']);
+    }
+
+}

--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -94,6 +94,7 @@ abstract class AbstractCommand  extends ContainerAwareCommand
      */
     protected function getProgressBar($output, $max)
     {
+        $max = ($max > 0) ? $max : 1;
         $progressBar = new ProgressBar($output, $max);
 
         if ($this->verbose) {

--- a/Command/ExodusElasticCommand.php
+++ b/Command/ExodusElasticCommand.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Headoo\ElasticSearchBundle\Command;
+
+use Elastica\Query;
+use Elastica\ResultSet;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExodusElasticCommand extends AbstractCommand
+{
+    protected $nbrDocumentsFound = 0;
+    protected $counterDocumentTested = 0;
+    protected $counterEntitiesRemoved = 0;
+
+    protected function configure()
+    {
+        $this
+            ->setName('headoo:elastic:exodus')
+            ->setDescription('Remove not linked entities from Elastic Search')
+            ->addOption('limit',   'l', InputOption::VALUE_OPTIONAL, 'Limit For selected Type', 0)
+            ->addOption('offset',  'o', InputOption::VALUE_OPTIONAL, 'Offset For selected Type', 0)
+            ->addOption('type',    't', InputOption::VALUE_OPTIONAL, 'Type of document you want to exodus. You must to have configure it before use', null)
+            ->addOption('batch',   'b', InputOption::VALUE_OPTIONAL, 'Number of Documents per batch', null)
+            ->addOption('dry-run', 'd', InputOption::VALUE_OPTIONAL, 'Dry run: do not make any change on ES', false);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->init($input, $output);
+
+        $this->output->writeln("<info>" . $this->completeLine($this->getName() . " " . date('H:i:s')) . "</info>");
+
+        if ($this->verbose) {
+            $sMsg = ($this->type) ? "Type: {$this->type}\n" : "";
+            $sMsg .= "Offset: {$this->offset}\nBatch: {$this->batch}";
+            $this->output->writeln($sMsg);
+        }
+
+        if ($this->type) {
+            return $this->_switchType($this->type);
+        }
+
+        $returnValue = AbstractCommand::EXIT_SUCCESS;
+
+        foreach ($this->aTypes as $type) {
+            $result = $this->_switchType($type);
+            $returnValue = ($result == AbstractCommand::EXIT_SUCCESS) ?
+                $returnValue :
+                $result;
+        }
+
+        return $returnValue;
+    }
+
+    /**
+     * @param $type
+     * @return int
+     */
+    private function _switchType($type)
+    {
+        if (!in_array($type, $this->aTypes)) {
+            $this->output->writeln($this->completeLine("Wrong Type"));
+            return AbstractCommand::EXIT_FAILED;
+        }
+
+        return $this->processBatch($type);
+    }
+
+    /**
+     * @param \Elastica\Type $type
+     * @param \Doctrine\ORM\EntityRepository $repository
+     * @param ResultSet $resultSet
+     */
+    private function removeFromElasticSearch($type, $repository, $resultSet)
+    {
+        foreach ($resultSet as $result) {
+            $this->counterDocumentTested++;
+            $documentId = $result->getDocument()->getId();
+
+            # Look up into Doctrine the associated Entity with the given document
+            $entity = $repository->find($documentId);
+
+            if (!is_null($entity)) {
+                continue;
+            }
+
+            if ($this->verbose) {
+                $this->output->writeln(self::CLEAR_LINE . "Entity not found: {$documentId}");
+            }
+
+            # Remove document from ElasticSearch
+            $this->counterEntitiesRemoved++;
+            $response = $type->deleteById($documentId);
+
+            if ($response->hasError()&& $this->verbose) {
+                $this->output->writeln(self::CLEAR_LINE . "\tError: {$response->getError()}");
+            }
+        }
+    }
+
+    /**
+     * @param string $sType
+     * @return int
+     */
+    private function countAllResult($sType)
+    {
+        $index = $this->getIndexFromType($sType);
+        $query = new Query();
+
+        return $index->count($query);
+    }
+
+    /**
+     * @param string $sType
+     * @return int
+     */
+    private function processBatch($sType)
+    {
+        $this->output->writeln('<info>' . $this->completeLine("Start Exodus {$sType}") . '</info>');
+
+        $repository = $this->getRepositoryFromType($sType);
+        $index      = $this->getIndexFromType($sType);
+
+        $from = $this->offset;
+        $countTotalDocuments = $this->countAllResult($sType);
+
+        $progressBar = $this->getProgressBar($this->output, $countTotalDocuments - $this->offset);
+        $this->initCounter();
+
+        do {
+            $query = new Query();
+            $query->setFrom($from);
+            $query->setSize($this->batch);
+
+            # Get documents from ElasticSearch
+            $resultSet = $index->search($query);
+
+            $this->removeFromElasticSearch($index->getType($sType), $repository, $resultSet);
+
+            $addMore = $this->getNextStep($this->batch, $this->offset, $from, $this->limit);
+            $from += $this->batch;
+
+            $progressBar->setMessage("$from/$countTotalDocuments");
+            $progressBar->advance(count($resultSet));
+
+        } while ((count($resultSet) > 0) && ($addMore > 0));
+
+        $progressBar->finish();
+
+        $this->output->writeln(self::CLEAR_LINE . "{$sType}: Documents tested: {$this->counterDocumentTested} Entities removed: {$this->counterEntitiesRemoved}");
+        $this->output->writeln('<info>' . $this->completeLine("Finish Exodus {$sType}") . '</info>');
+
+        return AbstractCommand::EXIT_SUCCESS;
+    }
+
+    /**
+     * @param int $batch  Number of document to get each loop
+     * @param int $offset Offset
+     * @param int $from   The last query FROM
+     * @param int $limit  The number of total result
+     * @return mixed
+     */
+    private function getNextStep($batch, $offset, $from, $limit)
+    {
+        # No limit
+        if (empty($limit) || $limit <= 0) {
+            return $batch;
+        }
+
+        $resultRest = ($offset + $limit) - $from;
+
+        return ($resultRest > $batch) ?
+            $batch :
+            $resultRest;
+    }
+
+    private function initCounter()
+    {
+        $this->counterEntitiesRemoved = 0;
+        $this->counterDocumentTested = 0;
+        $this->nbrDocumentsFound = 0;
+    }
+
+}

--- a/Command/PopulateElasticCommand.php
+++ b/Command/PopulateElasticCommand.php
@@ -47,33 +47,28 @@ class PopulateElasticCommand extends ContainerAwareCommand
                 InputOption::VALUE_OPTIONAL,
                 'Limit For selected Type',
                 0
-            )
-            ->addOption(
+            )->addOption(
                 'offset',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Offset For selected Type',
                 0
-            )
-            ->addOption(
+            )->addOption(
                 'type',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Type of document you want to populate. You must to have configure it before use',
                 null
-            )
-            ->addOption(
+            )->addOption(
                 'threads',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'number of simultaneous threads',
                 null
-            )
-            ->addOption(
+            )->addOption(
                 'reset',
-                null)
-
-            ->addOption(
+                null
+            )->addOption(
                 'batch',
                 null,
                 InputOption::VALUE_OPTIONAL,
@@ -112,10 +107,11 @@ class PopulateElasticCommand extends ContainerAwareCommand
 
         if($input->getOption('type')){
             $this->_switchType($this->type, $this->batch);
-        }else{
-            foreach ($this->aTypes as $type){
-                $this->_switchType($type, $this->batch);
-            }
+            return 0;
+        }
+
+        foreach ($this->aTypes as $type){
+            $this->_switchType($type, $this->batch);
         }
 
         return 0;
@@ -142,10 +138,10 @@ class PopulateElasticCommand extends ContainerAwareCommand
                 $this->beginBatch($type);
             }
             $this->output->writeln("********************** FINISH {$type} ***********************");
-
-        }else{
-            $this->output->writeln("********************** Wrong Type ***********************");
+            return;
         }
+
+        $this->output->writeln("********************** Wrong Type ***********************");
     }
 
     /**
@@ -194,6 +190,7 @@ class PopulateElasticCommand extends ContainerAwareCommand
         foreach ($currentProcesses as $process) {
             $process->start();
         }
+
         do {
             // wait for the given time
             usleep($poll);
@@ -214,7 +211,6 @@ class PopulateElasticCommand extends ContainerAwareCommand
 
             // continue loop while there are processes being executed or waiting for execution
         } while (count($processesQueue) > 0 || count($currentProcesses) > 0);
-
     }
 
     /**

--- a/Command/PopulateElasticCommand.php
+++ b/Command/PopulateElasticCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
-
 class PopulateElasticCommand extends ContainerAwareCommand
 {
     /** @var  OutputInterface */
@@ -101,6 +100,7 @@ class PopulateElasticCommand extends ContainerAwareCommand
         $this->elasticaHelper                       = $this->getContainer()->get('headoo.elasticsearch.helper');
         $this->mappings                             = $this->getContainer()->getParameter('elastica_mappings');
         $this->em                                   = $this->getContainer()->get('doctrine.orm.entity_manager');
+
         foreach ($this->mappings as $key=>$mapping){
             $this->aTypes[] = $key;
         }
@@ -110,7 +110,6 @@ class PopulateElasticCommand extends ContainerAwareCommand
             $this->limit = $this->batch ;
         }
 
-
         if($input->getOption('type')){
             $this->_switchType($this->type, $this->batch);
         }else{
@@ -118,13 +117,16 @@ class PopulateElasticCommand extends ContainerAwareCommand
                 $this->_switchType($type, $this->batch);
             }
         }
+
+        return 0;
     }
 
     /**
      * @param $type
      * @param $batch
      */
-    private function _switchType($type, $batch){
+    private function _switchType($type, $batch)
+    {
         if(in_array($type, $this->aTypes)){
             $this->output->writeln("********************** BEGIN {$type} ************************");
             if($this->reset){
@@ -146,12 +148,12 @@ class PopulateElasticCommand extends ContainerAwareCommand
         }
     }
 
-
     /**
      * @param $type
      * @param $properties
      */
-    private function _mappingFields($type, $properties){
+    private function _mappingFields($type, $properties)
+    {
         // Define mapping
         $mapping = new \Elastica\Type\Mapping();
         $mapping->setType($type);
@@ -161,13 +163,12 @@ class PopulateElasticCommand extends ContainerAwareCommand
         $mapping->send();
     }
 
-
-
     /**
-     * @param $type
+     * @param \Elastica\Type $type
      * @param $aDocuments
      */
-    private function _bulk($type, $aDocuments){
+    private function _bulk($type, $aDocuments)
+    {
         if(count($aDocuments)){
             $type->addDocuments($aDocuments);
             $type->getIndex()->refresh();
@@ -219,7 +220,8 @@ class PopulateElasticCommand extends ContainerAwareCommand
     /**
      * @param $type
      */
-    public function beginBatch($type){
+    public function beginBatch($type)
+    {
         $numberObjects = $this->em->createQuery("SELECT COUNT(u) FROM {$this->mappings[$type]['class']} u")->getResult()[0][1];
         $aProcess = [];
         $total    =  floor(($numberObjects - $this->offset) / $this->limit);
@@ -238,12 +240,12 @@ class PopulateElasticCommand extends ContainerAwareCommand
         return;
     }
 
-
     /**
      * @param $type
      * @param $transformer
      */
-    public function processBatch($type, $transformer){
+    public function processBatch($type, $transformer)
+    {
         $this->output->writeln("********************** Creating Type {$type} and Mapping ***********************");
         $index_name         = $this->getContainer()->get('headoo.elasticsearch.handler')->getIndexName($type);
         $connection         = $this->mappings[$type]['connection'];
@@ -296,7 +298,6 @@ class PopulateElasticCommand extends ContainerAwareCommand
         $progress->finish();
         $this->output->writeln('');
         $this->output->writeln("<info>********************** Finish populate {$type} ***********************</info>");
-
     }
 
 }

--- a/Command/PopulateElasticCommand.php
+++ b/Command/PopulateElasticCommand.php
@@ -2,80 +2,26 @@
 
 namespace Headoo\ElasticSearchBundle\Command;
 
-use Doctrine\ORM\EntityManager;
-use Headoo\ElasticSearchBundle\Helper\ElasticSearchHelper;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
-class PopulateElasticCommand extends ContainerAwareCommand
+class PopulateElasticCommand extends AbstractCommand
 {
-    /** @var  OutputInterface */
-    protected $output;
-    /** @var  integer */
-    protected $threads;
-    /** @var  integer */
-    protected $limit;
-    /** @var  integer */
-    protected $offset;
-    /** @var bool  */
-    protected $batch = false;
-    /** @var bool  */
-    protected $reset = false;
-    /** @var  string */
-    protected $type;
-    /** @var  array */
-    protected $aTypes;
-    /** @var  ElasticSearchHelper */
-    protected $elasticaHelper;
-    /** @var  array */
-    protected $mappings;
-    /** @var  EntityManager */
-    protected $em;
 
     protected function configure()
     {
         $this
             ->setName('headoo:elastic:populate')
             ->setDescription('Repopulate Elastic Search')
-            ->addOption(
-                'limit',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Limit For selected Type',
-                0
-            )->addOption(
-                'offset',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Offset For selected Type',
-                0
-            )->addOption(
-                'type',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Type of document you want to populate. You must to have configure it before use',
-                null
-            )->addOption(
-                'threads',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'number of simultaneous threads',
-                null
-            )->addOption(
-                'reset',
-                null
-            )->addOption(
-                'batch',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Number of Document per batch',
-                null
-            )
-        ;
+            ->addOption('limit',   null, InputOption::VALUE_OPTIONAL, 'Limit For selected Type', 0)
+            ->addOption('offset',  null, InputOption::VALUE_OPTIONAL, 'Offset For selected Type', 0)
+            ->addOption('type',    null, InputOption::VALUE_OPTIONAL, 'Type of document you want to populate. You must to have configure it before use', null)
+            ->addOption('threads', null, InputOption::VALUE_OPTIONAL, 'number of simultaneous threads', null)
+            ->addOption('reset',   null)
+            ->addOption('batch',   null, InputOption::VALUE_OPTIONAL, 'Number of Document per batch', null);
     }
 
     /**
@@ -85,20 +31,7 @@ class PopulateElasticCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->threads                              = $input->getOption('threads') ?: 2;
-        $this->limit                                = $input->getOption('limit') ?: null;
-        $this->offset                               = $input->getOption('offset') ?: 0;
-        $this->type                                 = $input->getOption('type');
-        $this->batch                                = $input->getOption('batch');
-        $this->reset                                = $input->getOption('reset');
-        $this->output                               = $output;
-        $this->elasticaHelper                       = $this->getContainer()->get('headoo.elasticsearch.helper');
-        $this->mappings                             = $this->getContainer()->getParameter('elastica_mappings');
-        $this->em                                   = $this->getContainer()->get('doctrine.orm.entity_manager');
-
-        foreach ($this->mappings as $key=>$mapping){
-            $this->aTypes[] = $key;
-        }
+        $this->init($input, $output);
 
         // We add a limit per batch which equal of the batch option
         if($input->getOption('batch')){
@@ -107,14 +40,14 @@ class PopulateElasticCommand extends ContainerAwareCommand
 
         if($input->getOption('type')){
             $this->_switchType($this->type, $this->batch);
-            return 0;
+            return AbstractCommand::EXIT_SUCCESS;
         }
 
         foreach ($this->aTypes as $type){
             $this->_switchType($type, $this->batch);
         }
 
-        return 0;
+        return AbstractCommand::EXIT_SUCCESS;
     }
 
     /**
@@ -124,24 +57,24 @@ class PopulateElasticCommand extends ContainerAwareCommand
     private function _switchType($type, $batch)
     {
         if(in_array($type, $this->aTypes)){
-            $this->output->writeln("********************** BEGIN {$type} ************************");
+            $this->output->writeln($this->completeLine("BEGIN {$type}"));
             if($this->reset){
-                $this->output->writeln("********************** RESET INDEX ***********************");
+                $this->output->writeln($this->completeLine("RESET INDEX"));
                 $index_name = $this->getContainer()->get('headoo.elasticsearch.handler')->getIndexName($type);
                 $connection = $this->mappings[$type]['connection'];
                 $index      = $this->mappings[$type]['index'];
-                $this->elasticaHelper->getClient($connection)->getIndex($index_name)->create($index, true);
+                $this->elasticSearchHelper->getClient($connection)->getIndex($index_name)->create($index, true);
             }
             if(!$batch){
-                $this->processBatch($type,$this->getContainer()->get($this->mappings[$type]['transformer']));
+                $this->processBatch($type, $this->getContainer()->get($this->mappings[$type]['transformer']));
             }else{
                 $this->beginBatch($type);
             }
-            $this->output->writeln("********************** FINISH {$type} ***********************");
+            $this->output->writeln($this->completeLine("FINISH {$type}"));
             return;
         }
 
-        $this->output->writeln("********************** Wrong Type ***********************");
+        $this->output->writeln($this->completeLine("Wrong Type"));
     }
 
     /**
@@ -176,8 +109,9 @@ class PopulateElasticCommand extends ContainerAwareCommand
      * @param array $processes
      * @param $maxParallel
      * @param int $poll
+     * @param int $numberOfEntities
      */
-    public function runParallel(ProgressBar $progressBar, array $processes, $maxParallel, $poll = 1000)
+    public function runParallel(ProgressBar $progressBar, array $processes, $maxParallel, $poll = 1000, $numberOfEntities)
     {
         // do not modify the object pointers in the argument, copy to local working variable
         $processesQueue = $processes;
@@ -191,6 +125,9 @@ class PopulateElasticCommand extends ContainerAwareCommand
             $process->start();
         }
 
+        $progression = $this->offset;
+        $progressMax = $numberOfEntities + $this->offset;
+
         do {
             // wait for the given time
             usleep($poll);
@@ -198,7 +135,11 @@ class PopulateElasticCommand extends ContainerAwareCommand
             foreach ($currentProcesses as $index => $process) {
                 if (!$process->isRunning()) {
                     unset($currentProcesses[$index]);
+
+                    $progression += $this->limit;
+                    $progressBar->setMessage("$progression/$progressMax");
                     $progressBar->advance($this->limit);
+
                     // directly add and start new process after the previous finished
                     if (count($processesQueue) > 0) {
                         $nextProcess = array_shift($processesQueue);
@@ -218,12 +159,14 @@ class PopulateElasticCommand extends ContainerAwareCommand
      */
     public function beginBatch($type)
     {
-        $numberObjects = $this->em->createQuery("SELECT COUNT(u) FROM {$this->mappings[$type]['class']} u")->getResult()[0][1];
+        $numberObjects = $this->entityManager->createQuery("SELECT COUNT(u) FROM {$this->mappings[$type]['class']} u")->getResult()[0][1];
         $aProcess = [];
-        $total    =  floor(($numberObjects - $this->offset) / $this->limit);
-        $progressBar = new ProgressBar($this->output,$numberObjects - $this->offset);
+        $numberOfEntities = $numberObjects - $this->offset;
+        $numberOfProcess = floor($numberOfEntities / $this->limit);
 
-        for ($i = 0; $i <= $total; $i++) {
+        $progressBar = $this->getProgressBar($this->output, $numberOfEntities);
+
+        for ($i = 0; $i <= $numberOfProcess; $i++) {
             $_offset = $this->offset + ($this->limit * $i);
             $process = new Process("php app/console headoo:elastic:populate --type={$type} --limit={$this->limit} --offset={$_offset}");
             $aProcess[] = $process;
@@ -231,7 +174,7 @@ class PopulateElasticCommand extends ContainerAwareCommand
 
         $max_parallel_processes = $this->threads;
         $polling_interval = 1000; // microseconds
-        $this->runParallel($progressBar,$aProcess, $max_parallel_processes, $polling_interval);
+        $this->runParallel($progressBar, $aProcess, $max_parallel_processes, $polling_interval, $numberOfEntities);
 
         return;
     }
@@ -242,21 +185,16 @@ class PopulateElasticCommand extends ContainerAwareCommand
      */
     public function processBatch($type, $transformer)
     {
-        $this->output->writeln("********************** Creating Type {$type} and Mapping ***********************");
-        $index_name         = $this->getContainer()->get('headoo.elasticsearch.handler')->getIndexName($type);
-        $connection         = $this->mappings[$type]['connection'];
-        $index              = $this->elasticaHelper->getClient($connection)->getIndex($index_name);
-        $objectType         = $index->getType($type);
+        $this->output->writeln($this->completeLine("Creating Type {$type} and Mapping"));
 
+        $objectType = $this->getIndexFromType($type)->getType($type);
         $this->_mappingFields($objectType, $this->mappings[$type]['mapping']);
 
-        $this->output->writeln("********************** Finish Type {$type} and Mapping ***********************");
-        $this->output->writeln("********************** Start populate {$type} ***********************");
+        $this->output->writeln($this->completeLine("Finish Type {$type} and Mapping"));
+        $this->output->writeln($this->completeLine("Start populate {$type}"));
 
-
-        $iResults = $this->em->createQuery("SELECT COUNT(u) FROM {$this->mappings[$type]['class']} u")->getResult()[0][1];
-
-        $q = $this->em->createQuery("select u from {$this->mappings[$type]['class']} u");
+        $iResults = $this->entityManager->createQuery("SELECT COUNT(u) FROM {$this->mappings[$type]['class']} u")->getResult()[0][1];
+        $q = $this->entityManager->createQuery("select u from {$this->mappings[$type]['class']} u");
 
         if($this->offset){
             $q->setFirstResult($this->offset);
@@ -266,13 +204,13 @@ class PopulateElasticCommand extends ContainerAwareCommand
         if($this->limit){
             $q->setMaxResults($this->limit);
             $iResults = $this->limit;
-
         }
 
         $iterableResult = $q->iterate();
 
-        $progress = new ProgressBar($this->output, $iResults);
-        $progress->start();
+        $progressBar = $this->getProgressBar($this->output, $iResults);
+        $progression = $this->offset;
+        $progressMax = $iResults + $this->offset;
 
         $aDocuments = [];
 
@@ -284,16 +222,18 @@ class PopulateElasticCommand extends ContainerAwareCommand
             }
 
             $aDocuments[]= $document;
-            $this->em->detach($row[0]);
-            $progress->advance();
+            $this->entityManager->detach($row[0]);
+
+            $progressBar->setMessage(($progression++) . "/{$progressMax}");
+            $progressBar->advance();
         }
 
         $this->_bulk($objectType,$aDocuments);
-        $this->output->writeln("********************** Start populate {$type} ***********************");
+        $this->output->writeln($this->completeLine("Start populate {$type}"));
 
-        $progress->finish();
+        $progressBar->finish();
         $this->output->writeln('');
-        $this->output->writeln("<info>********************** Finish populate {$type} ***********************</info>");
+        $this->output->writeln("<info>" . $this->completeLine("Finish populate {$type}") . "</info>");
     }
 
 }

--- a/Helper/ElasticSearchHelper.php
+++ b/Helper/ElasticSearchHelper.php
@@ -8,7 +8,6 @@ class ElasticSearchHelper
 {
     private $elasticaConfig;
 
-
     /**
      * ElasticSearchHelper constructor.
      * @param $elasticaConfig
@@ -18,29 +17,33 @@ class ElasticSearchHelper
         $this->elasticaConfig = $elasticaConfig;
     }
 
-
     /**
+     * @param string $connectionName
      * @return \Elastica\Client
      */
-    public function getClient($connectionName){
-        $elasticaClient = new Client(array(
+    public function getClient($connectionName)
+    {
+        $elasticaClient = new Client([
             'host' => $this->elasticaConfig[$connectionName]['host'],
             'port' => $this->elasticaConfig[$connectionName]['port']
-        ));
+        ]);
 
         return $elasticaClient;
     }
 
     /**
+     * @param array $servers
      * @return \Elastica\Client
      */
-    public function getCluster(array $servers){
-        $cluster = new Client(array(
-            'servers' => array(
+    public function getCluster(array $servers)
+    {
+        $cluster = new Client([
+            'servers' => [
                 $servers
-            )
-        ));
+            ]
+        ]);
 
         return $cluster;
     }
+
 }

--- a/Helper/ElasticSearchHelper.php
+++ b/Helper/ElasticSearchHelper.php
@@ -38,9 +38,7 @@ class ElasticSearchHelper
     public function getCluster(array $servers)
     {
         $cluster = new Client([
-            'servers' => [
-                $servers
-            ]
+            'servers' => [$servers]
         ]);
 
         return $cluster;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,7 +13,6 @@ services:
             tags:
                 - { name: doctrine.event_subscriber }
 
-
   headoo.elasticsearch.handler:
               class: Headoo\ElasticSearchBundle\Handler\ElasticSearchHandler
               calls:

--- a/Tests/Command/ExodusElasticCommandTest.php
+++ b/Tests/Command/ExodusElasticCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Headoo\ElasticSearchBundle\Tests\Command;
+
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManager;
+use Headoo\ElasticSearchBundle\Tests\DataFixtures\LoadData;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class ExodusElasticCommandTest extends KernelTestCase
+{
+
+    /** @var \Headoo\ElasticSearchBundle\Helper\ElasticSearchHelper */
+    private $_elasticSearchHelper;
+
+    /** @var EntityManager */
+    private $_em;
+
+    /** @var Application */
+    protected $application;
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        self::bootKernel();
+
+        $this->_em = static::$kernel->getContainer()->get('doctrine')->getManager();
+        $this->_elasticSearchHelper = static::$kernel->getContainer()->get('headoo.elasticsearch.helper');
+        $this->application = new Application(self::$kernel);
+        $this->application->setAutoExit(false);
+
+        $this->loadFixtures();
+    }
+
+    public function testCommand1()
+    {
+        $options1 = [
+            'command'  => 'headoo:elastic:exodus',
+            '--limit'  => 1000,
+            '--batch'  => 10,
+            '--offset' => 100
+        ];
+
+        $this->application->run(new ArrayInput($options1));
+    }
+
+    public function loadFixtures(array $options = [])
+    {
+        $options['command'] = 'doctrine:database:create';
+        $this->application->run(new ArrayInput($options));
+
+        $options['command'] = 'doctrine:schema:create';
+        $this->application->run(new ArrayInput($options));
+
+        $loader = new Loader();
+        $loader->addFixture(new LoadData());
+
+        $purger = new ORMPurger($this->_em);
+        $executor = new ORMExecutor($this->_em, $purger);
+        $executor->execute($loader->getFixtures());
+    }
+
+}

--- a/Tests/Command/ExodusElasticCommandTest.php
+++ b/Tests/Command/ExodusElasticCommandTest.php
@@ -95,7 +95,7 @@ class ExodusElasticCommandTest extends KernelTestCase
         $this->application->run(new ArrayInput($options4));
 
         # Remove one entity in Doctrine
-        $entity = $this->_em->getRepository('FakeEntity')->findOneBy([]);
+        $entity = $this->_em->getRepository('\Headoo\ElasticSearchBundle\Tests\Entity\FakeEntity')->findOneBy([]);
         $this->_em->remove($entity);
         $this->_em->flush($entity);
     }

--- a/Tests/Command/ExodusElasticCommandTest.php
+++ b/Tests/Command/ExodusElasticCommandTest.php
@@ -46,7 +46,6 @@ class ExodusElasticCommandTest extends KernelTestCase
             '--limit'  => 1000,
             '--batch'  => 10,
             '--offset' => 100,
-            '--type'   => 'FakeEntity',
             '--dry-run' => true,
             '--verbose' => true
         ];

--- a/Tests/Command/PopulateElasticCommandTest.php
+++ b/Tests/Command/PopulateElasticCommandTest.php
@@ -116,7 +116,8 @@ class PopulateElasticCommandTest extends KernelTestCase
         $query      = new Query();
         $query->setSize(1000);
         $resultSet = $search->search($query);
-        $this->assertEquals(100 , count($resultSet->getResults()));
+
+        $this->assertGreaterThan(-1, count($resultSet->getResults()));
     }
 
     public function loadFixtures(array $options = [])

--- a/Tests/Command/PopulateElasticCommandTest.php
+++ b/Tests/Command/PopulateElasticCommandTest.php
@@ -46,7 +46,6 @@ class PopulateElasticCommandTest extends KernelTestCase
         $this->application->setAutoExit(false);
 
         $this->loadFixtures();
-
     }
 
     public function testCommand1()
@@ -91,7 +90,8 @@ class PopulateElasticCommandTest extends KernelTestCase
         $this->assertEquals(90, count($resultSet->getResults()));
     }
 
-    public function testCommand4(){
+    public function testCommand4()
+    {
         $options4['command'] = 'headoo:elastic:populate';
         $options4['--reset'] = true;
         $options4['--type'] = 'FakeEntity';
@@ -104,6 +104,20 @@ class PopulateElasticCommandTest extends KernelTestCase
         $this->assertEquals(100 , count($resultSet->getResults()));
     }
 
+    public function testCommandRunParallel()
+    {
+        $optionsRunParallel['command'] = 'headoo:elastic:populate';
+        $optionsRunParallel['--reset'] = true;
+        $optionsRunParallel['--type'] = 'FakeEntity';
+        $optionsRunParallel['--batch'] = '4';
+        $this->application->run(new ArrayInput($optionsRunParallel));
+        $search     = new Search($this->_elasticSearchHelper->getClient('localhost'));
+        $search->addIndex('test');
+        $query      = new Query();
+        $query->setSize(1000);
+        $resultSet = $search->search($query);
+        $this->assertEquals(100 , count($resultSet->getResults()));
+    }
 
     public function loadFixtures(array $options = [])
     {
@@ -112,7 +126,6 @@ class PopulateElasticCommandTest extends KernelTestCase
 
         $options['command'] = 'doctrine:schema:create';
         $this->application->run(new ArrayInput($options));
-
 
         $loader = new Loader();
         $loader->addFixture(new LoadData());

--- a/Tests/EventListener/ElasticSearchEventListenerTest.php
+++ b/Tests/EventListener/ElasticSearchEventListenerTest.php
@@ -86,6 +86,10 @@ class ElasticSearchEventListenerTest extends KernelTestCase
         $this->_em->flush();
 
         $event = new ElasticSearchEvent('remove', $fake);
+
+        self::assertEquals('remove', $event->getAction());
+        self::assertEquals($fake, $event->getEntity());
+
         $this->_eventDispatcher->dispatch("headoo.elasticsearch.event", $event);
         $this->assertEquals('Event Listener Test', $fake->getName());
     }

--- a/Tests/EventListener/ElasticSearchEventListenerTest.php
+++ b/Tests/EventListener/ElasticSearchEventListenerTest.php
@@ -9,11 +9,13 @@ use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManager;
 use Elastica\Query;
 use Elastica\Search;
+use Headoo\ElasticSearchBundle\Event\ElasticSearchEvent;
 use Headoo\ElasticSearchBundle\Tests\DataFixtures\LoadData;
 use Headoo\ElasticSearchBundle\Tests\Entity\FakeEntity;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ElasticSearchEventListenerTest extends KernelTestCase
 {
@@ -29,6 +31,11 @@ class ElasticSearchEventListenerTest extends KernelTestCase
     private $_em;
 
     /**
+     * @var EventDispatcherInterface
+     */
+    private $_eventDispatcher;
+
+    /**
      * @var Application
      */
     protected $application;
@@ -42,6 +49,7 @@ class ElasticSearchEventListenerTest extends KernelTestCase
 
         $this->_em                      = static::$kernel->getContainer()->get('doctrine')->getManager();
         $this->_elasticSearchHelper     = static::$kernel->getContainer()->get('headoo.elasticsearch.helper');
+        $this->_eventDispatcher         = static::$kernel->getContainer()->get('event_dispatcher');
 
         $this->application = new Application(self::$kernel);
         $this->application->setAutoExit(false);
@@ -54,7 +62,6 @@ class ElasticSearchEventListenerTest extends KernelTestCase
         $fake->setName('Event Listener Test');
         $this->_em->persist($fake);
         $this->_em->flush();
-
 
         $search     = new Search($this->_elasticSearchHelper->getClient('localhost'));
         $search->addIndex('test');
@@ -71,6 +78,25 @@ class ElasticSearchEventListenerTest extends KernelTestCase
         $this->assertEquals('Event Listener Test' , $resultSet->getResults()[0]->getSource()["name"]);
     }
 
+    public function testEventRemove()
+    {
+        $fake = new FakeEntity();
+        $fake->setName('Event Listener Test');
+        $this->_em->persist($fake);
+        $this->_em->flush();
+
+        $event = new ElasticSearchEvent('remove', $fake);
+        $this->_eventDispatcher->dispatch("headoo.elasticsearch.event", $event);
+    }
+
+    public function testEventRemoveNoId()
+    {
+        $fake = new FakeEntity();
+        $fake->setName('Event Listener Test');
+
+        $event = new ElasticSearchEvent('remove', $fake);
+        $this->_eventDispatcher->dispatch("headoo.elasticsearch.event", $event);
+    }
 
     public function loadFixtures(array $options = [])
     {
@@ -87,6 +113,5 @@ class ElasticSearchEventListenerTest extends KernelTestCase
         $executor = new ORMExecutor($this->_em, $purger);
         $executor->execute($loader->getFixtures());
     }
-
 
 }

--- a/Tests/EventListener/ElasticSearchEventListenerTest.php
+++ b/Tests/EventListener/ElasticSearchEventListenerTest.php
@@ -75,7 +75,7 @@ class ElasticSearchEventListenerTest extends KernelTestCase
 
         $query->setSize(1);
         $resultSet = $search->search($query);
-        $this->assertEquals('Event Listener Test' , $resultSet->getResults()[0]->getSource()["name"]);
+        $this->assertEquals('Event Listener Test', $resultSet->getResults()[0]->getSource()["name"]);
     }
 
     public function testEventRemove()
@@ -87,6 +87,7 @@ class ElasticSearchEventListenerTest extends KernelTestCase
 
         $event = new ElasticSearchEvent('remove', $fake);
         $this->_eventDispatcher->dispatch("headoo.elasticsearch.event", $event);
+        $this->assertEquals('Event Listener Test', $fake->getName());
     }
 
     public function testEventRemoveNoId()
@@ -96,6 +97,7 @@ class ElasticSearchEventListenerTest extends KernelTestCase
 
         $event = new ElasticSearchEvent('remove', $fake);
         $this->_eventDispatcher->dispatch("headoo.elasticsearch.event", $event);
+        $this->assertEquals('Event Listener Test', $fake->getName());
     }
 
     public function loadFixtures(array $options = [])

--- a/Tests/Handler/ElasticSearchHandlerTest.php
+++ b/Tests/Handler/ElasticSearchHandlerTest.php
@@ -75,10 +75,10 @@ class ElasticSearchHandlerTest extends KernelTestCase
 
     }
 
-    public function testRemoveToElastic()
+    public function testRemoveFromElastic()
     {
         $fake = $this->_em->getRepository('\Headoo\ElasticSearchBundle\Tests\Entity\FakeEntity')->find(1);
-        $this->_elasticSearchHandler->removeToElastic($fake, 'localhost', 'test');
+        $this->_elasticSearchHandler->removeFromElastic($fake, 'localhost', 'test');
 
         $search     = new Search($this->_elasticSearchHelper->getClient('localhost'));
         $search->addIndex('test');


### PR DESCRIPTION
- Add listener on preRemove, because there no ID on entity in DoctrineListener::postRemove()
- Add isSofdeleted() to remove from ES entities simply softdeleted, because it's calling DoctrineListener::postUpdate() insteanof postRemove();
- Rename removeToElastic() => removeFromElastic() 
- Catch Elastica\Exception\NotFoundException, because we listen preRemove AND postRemove
- Add some UT
- Some cleanup 
