### PR TITLE
Fix memory leak / Handle process error

### DIFF
--- a/Command/PopulateElasticCommand.php
+++ b/Command/PopulateElasticCommand.php
@@ -163,6 +163,8 @@ class PopulateElasticCommand extends AbstractCommand
             // continue loop while there are processes being executed or waiting for execution
         } while (count($processesQueue) > 0 || count($currentProcesses) > 0);
 
+        $progressBar->finish();
+
         return $returnValue;
     }
 


### PR DESCRIPTION
- Avoid memory leack (http://konradpodgorski.com/blog/2013/01/18/how-to-avoid-memory-leaks-in-symfony-2-commands/)
- Replicates options to subprocess (--env=prod)
- Handles and shows errors from the subprocess 